### PR TITLE
Feature/use babel parser

### DIFF
--- a/blueprints/cursor/files/__root__/state.js.tpl
+++ b/blueprints/cursor/files/__root__/state.js.tpl
@@ -6,10 +6,10 @@ const initialState = process.env.IS_BROWSER
 
 // Custom revirer example, check how to convert JSON to custom record types.
 // http://facebook.github.io/immutable-js/docs/#/fromJS
-export const state = new State(initialState, function(key, value) {
+export const appState = new State(initialState, function(key, value) {
 
 });
 
-export const appCursor = state.cursor(['app']);
-export const i18nCursor = state.cursor(['i18n']);
-export const pendingActionsCursor = state.cursor(['pendingActions']);
+export const appCursor = appState.cursor(['app']);
+export const i18nCursor = appState.cursor(['i18n']);
+export const pendingActionsCursor = appState.cursor(['pendingActions']);

--- a/lib/models/file.js
+++ b/lib/models/file.js
@@ -21,7 +21,9 @@ module.exports = File;
  * @constructor
  */
 function File(filestring) {
-  this.ast = recast.parse(filestring);
+  this.ast = recast.parse(filestring, {
+    esprima: require('babel-core')
+  });
   this.body = this.ast.program.body;
 }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/grabbou"
   },
   "dependencies": {
-    "babel-core": "^5.6.15",
+    "babel-core": "^5.6.16",
     "bluebird": "^2.9.25",
     "camel-case": "^1.1.2",
     "chalk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "url": "https://github.com/grabbou"
   },
   "dependencies": {
+    "babel-core": "^5.6.15",
     "bluebird": "^2.9.25",
     "camel-case": "^1.1.2",
     "chalk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "param-case": "^1.1.1",
     "pascal-case": "^1.1.1",
     "path-case": "^1.1.1",
-    "recast": "^0.10.12",
+    "recast": "^0.10.16",
     "require-directory": "^2.1.0",
     "rimraf": "^2.3.4",
     "sinon": "^1.14.1",


### PR DESCRIPTION
Now that Benjamn updated his modules, we can safely use babel-core to generate the AST. You should probably also publish a new version of the cli to NPM.