### PR TITLE
Add decorator option to generate component

### DIFF
--- a/blueprints/component/files/__root__/components/__name__.react.js.tpl
+++ b/blueprints/component/files/__root__/components/__name__.react.js.tpl
@@ -1,7 +1,7 @@
-{{#isPlainComponent}}
 import Component from '{{{folderPath}}}/component.react';
 import React from 'react';
 
+{{#isPlainComponent}}
 export default class {{className}} extends Component {
 
   render() {
@@ -11,10 +11,8 @@ export default class {{className}} extends Component {
 }
 {{/isPlainComponent}}
 {{^isPlainComponent}}
-import Component from '{{{folderPath}}}/component.react';
-import React from 'react';
-
-export default function {{camelName}}{{^isDecorator}}Component{{/isDecorator}}(BaseComponent) {
+{{^isDecorator}}
+export default function {{camelName}}Component(BaseComponent) {
 
   class {{className}} extends Component {
     render() {
@@ -27,4 +25,21 @@ export default function {{camelName}}{{^isDecorator}}Component{{/isDecorator}}(B
   return {{className}};
 
 }
+{{/isDecorator}}
+{{#isDecorator}}
+export default function {{camelName}}() {
+    return function decorator(BaseComponent) {
+        return class {{className}} extends Component {
+
+            render() {
+                return <BaseComponent {...this.props} />;
+            }
+        };
+    }
+
+    {{className}}.displayName = `${BaseComponent.name}{{className}}`;
+
+    return {{className}};
+}
+{{/isDecorator}}
 {{/isPlainComponent}}

--- a/blueprints/component/files/__root__/components/__name__.react.js.tpl
+++ b/blueprints/component/files/__root__/components/__name__.react.js.tpl
@@ -14,7 +14,7 @@ export default class {{className}} extends Component {
 import Component from '{{{folderPath}}}/component.react';
 import React from 'react';
 
-export default function {{camelName}}Component(BaseComponent) {
+export default function {{camelName}}{{^isDecorator}}Component{{/isDecorator}}(BaseComponent) {
 
   class {{className}} extends Component {
     render() {

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -12,11 +12,16 @@ module.exports = {
     type: Boolean,
     name: '-p, --plain-component',
     description: 'Generates pure component that does not wrap another one'
+  }, {
+    type: Boolean,
+    name: '-d, --decorator',
+    description: 'Generates a decorator'
   }],
 
   locals: function(file, options) {
     return {
-      isPlainComponent: !!options.flags.plainComponent
+      isPlainComponent: !!options.flags.plainComponent,
+      isDecorator: !!options.flags.decorator
     };
   }
 };


### PR DESCRIPTION
Since a decorator shouldn't have the "Component" suffix to its name, this is just a handy thing. I could also add a `functionToDecorate`, what do you think of this?

Moreover, it could be nice to factorise the templates, no (avoid repeating the `import` for instance), or do you prefer it this way?